### PR TITLE
Speech Recognition API updates

### DIFF
--- a/Source/CharismaModule/Public/CharismaEvents.h
+++ b/Source/CharismaModule/Public/CharismaEvents.h
@@ -388,79 +388,31 @@ struct FCharismaMessageHistoryResponse
 };
 
 USTRUCT(BlueprintType)
-struct FCharismaSpeechRecognitionResultEventAWSResultAlternatives
-{
-	GENERATED_USTRUCT_BODY()
-
-	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
-	FString Transcript;
-
-	MSGPACK_DEFINE_MAP(Transcript);
-};
-
-USTRUCT(BlueprintType)
-struct FCharismaSpeechRecognitionResultEventAWSResult
-{
-	GENERATED_USTRUCT_BODY()
-
-	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
-	FString ResultId;
-
-	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
-	float StartTime;
-
-	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
-	float EndTime;
-
-	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
-	bool IsPartial;
-
-	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
-	TArray<FCharismaSpeechRecognitionResultEventAWSResultAlternatives> Alternatives;
-
-	MSGPACK_DEFINE_MAP(ResultId, StartTime, EndTime, IsPartial, Alternatives);
-};
-
-USTRUCT(BlueprintType)
-struct FCharismaSpeechRecognitionResultEventAWSTranscript
-{
-	GENERATED_USTRUCT_BODY()
-
-	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
-	TArray<FCharismaSpeechRecognitionResultEventAWSResult> Results;
-
-	MSGPACK_DEFINE_MAP(Results);
-};
-
-USTRUCT(BlueprintType)
-struct FCharismaSpeechRecognitionResultEventAWSTranscriptEvent
-{
-	GENERATED_USTRUCT_BODY()
-
-	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
-	FCharismaSpeechRecognitionResultEventAWSTranscript Transcript;
-
-	MSGPACK_DEFINE_MAP(Transcript);
-};
-
-USTRUCT(BlueprintType)
-struct FCharismaSpeechRecognitionResultEventAWS
-{
-	GENERATED_USTRUCT_BODY()
-
-	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
-	FCharismaSpeechRecognitionResultEventAWSTranscriptEvent TranscriptEvent;
-
-	MSGPACK_DEFINE_MAP(TranscriptEvent);
-};
-
-USTRUCT(BlueprintType)
 struct FCharismaSpeechRecognitionResultEvent
 {
 	GENERATED_USTRUCT_BODY()
+		
+	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
+	FString Text;
+	;
 
 	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
-	FString Transcript;
+	bool SpeechFinal;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
+	bool IsFinal;
+
+	MSGPACK_DEFINE_MAP(MSGPACK_NVP("speechFinal", SpeechFinal),
+		MSGPACK_NVP("isFinal", IsFinal),
+		MSGPACK_NVP("text", Text));
+};
+
+struct FSpeechRecognitionErrorResult
+{
+	std::string message;
+	std::string errorOccuredWhen;
+
+	MSGPACK_DEFINE_MAP(message, errorOccuredWhen);
 };
 
 // Events sent from client -> server
@@ -512,14 +464,12 @@ struct ResumePayload
 	MSGPACK_DEFINE_MAP(conversationUuid, speechConfig);
 };
 
-struct SpeechRecognitionStartServiceOptionsAWS
-{
-	std::string LanguageCode;
-};
-
 struct SpeechRecognitionStartPayload
 {
 	std::string service;
-	TOptional<SpeechRecognitionStartServiceOptionsAWS> serviceOptions;
-	MSGPACK_DEFINE_MAP(service);
+	TOptional<int> sampleRate;
+	TOptional<std::string> languageCode;
+	TOptional<std::string> encoding;
+
+	MSGPACK_DEFINE_MAP(service, sampleRate, languageCode, encoding);
 };

--- a/Source/CharismaModule/Public/CharismaEvents.h
+++ b/Source/CharismaModule/Public/CharismaEvents.h
@@ -394,7 +394,6 @@ struct FCharismaSpeechRecognitionResultEvent
 		
 	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
 	FString Text;
-	;
 
 	UPROPERTY(BlueprintReadOnly, Category = "Charisma|Event")
 	bool SpeechFinal;
@@ -409,10 +408,10 @@ struct FCharismaSpeechRecognitionResultEvent
 
 struct FSpeechRecognitionErrorResult
 {
-	std::string message;
-	std::string errorOccuredWhen;
+	std::string Message;
+	std::string ErrorOccuredWhen;
 
-	MSGPACK_DEFINE_MAP(message, errorOccuredWhen);
+	MSGPACK_DEFINE_MAP(MSGPACK_NVP("message", Message), MSGPACK_NVP("errorOccuredWhen", ErrorOccuredWhen));
 };
 
 // Events sent from client -> server

--- a/Source/CharismaModule/Public/Playthrough.h
+++ b/Source/CharismaModule/Public/Playthrough.h
@@ -25,20 +25,12 @@ enum class ECharismaSpeechAudioFormat : uint8
 };
 
 UENUM(BlueprintType, Category = "Charisma|Playthrough")
-enum class ECharismaSpeechRecognitionAWSLanguageCode : uint8
+enum class ECharismaSpeechRecognitionService : uint8
 {
-	DE_DE UMETA(DisplayName = "de-DE"),
-	EN_AU UMETA(DisplayName = "en-AU"),
-	EN_GB UMETA(DisplayName = "en-GB"),
-	EN_US UMETA(DisplayName = "en-US"),
-	ES_US UMETA(DisplayName = "es-US"),
-	FR_CA UMETA(DisplayName = "fr-CA"),
-	FR_FR UMETA(DisplayName = "fr-FR"),
-	IT_IT UMETA(DisplayName = "it-IT"),
-	JA_JP UMETA(DisplayName = "ja-JP"),
-	KO_KR UMETA(DisplayName = "ko-KR"),
-	PT_BR UMETA(DisplayName = "pt-BR"),
-	ZH_CN UMETA(DisplayName = "zh-CN"),
+	Unified UMETA(DisplayName = "unified"),
+	Google UMETA(DisplayName = "unified:google"),
+	AWS UMETA(DisplayName = "unified:aws"),
+	Deepgram UMETA(DisplayName = "unified:deepgram")
 };
 
 UENUM(BlueprintType, Category = "Charisma|Playthrough")
@@ -110,7 +102,11 @@ public:
 	void Pause() const;
 
 	UFUNCTION(BlueprintCallable, Category = "Charisma|Playthrough Events")
-	void StartSpeechRecognition(const ECharismaSpeechRecognitionAWSLanguageCode LanguageCode, bool& bWasSuccessful);
+		void StartSpeechRecognition(bool& bWasSuccessful,
+			const ECharismaSpeechRecognitionService service = ECharismaSpeechRecognitionService::AWS,
+			const FString languageCode = "en-US",
+			const FString encoding = "pcm",
+			const int32 sampleRate = 16000);
 
 	UFUNCTION(BlueprintCallable, Category = "Charisma|Playthrough Events")
 	void StopSpeechRecognition();
@@ -165,6 +161,9 @@ private:
 
 	UFUNCTION()
 	void ChangeConnectionState(ECharismaPlaythroughConnectionState NewConnectionState);
+
+	UFUNCTION()
+	FString GetSpeechRecognitionServiceString(const ECharismaSpeechRecognitionService Service);
 
 	// Member
 


### PR DESCRIPTION
- removed strict aws configuration
- added "unified" api versioning
- added samplerate and encoding into speechrecog Payload
- was not able to add timeInSeconds and confidence float fields. these would cause a crash as both mandatory and optional params